### PR TITLE
BLD: build the 2.2.x branch with older version of numpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
         - TEST_DEPENDS=
         - PLAT=x86_64
         - UNICODE_WIDTH=32
-        - NP_BUILD_DEP=1.10.1
+        - NP_BUILD_DEP=1.7.1
         - NP_TEST_DEP=1.11.3
         - MANYLINUX_URL=https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com
         - WHEELHOUSE_UPLOADER_USERNAME=travis-worker


### PR DESCRIPTION
@matthew-brett What is the policy on replacing published wheels?  Can we merge this, let them re-build and then re-upload the new ones?  Do we have to tack some suffix on?  Do we just have to do 2.2.4 to update this?