### PR TITLE
don't set a default backend, fixes #6

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -19,6 +19,7 @@ function pre_build {
         # See https://github.com/matplotlib/matplotlib/issues/10649
         export LDFLAGS="-headerpad_max_install_names"
         build_new_zlib
+    fi
     build_jpeg
     build_libpng
     build_bzip2
@@ -35,8 +36,6 @@ function pre_build {
 tests = True
 toolkits_tests = True
 
-[rc_options]
-backend = TkAgg
 EOF
 }
 

--- a/config.sh
+++ b/config.sh
@@ -19,11 +19,6 @@ function pre_build {
         # See https://github.com/matplotlib/matplotlib/issues/10649
         export LDFLAGS="-headerpad_max_install_names"
         build_new_zlib
-        local default_backend=macosx
-    else
-        # Tk not available by default on manylinux build container.
-        local default_backend=TkAgg
-    fi
     build_jpeg
     build_libpng
     build_bzip2
@@ -41,7 +36,7 @@ tests = True
 toolkits_tests = True
 
 [rc_options]
-backend = $default_backend
+backend = TkAgg
 EOF
 }
 


### PR DESCRIPTION
If you install the matplotlib wheel on a non-framework build of python, setting macosx as the default backend causes in `ImportError` (see #6). Since we can't tell whether or not we're installing into a framework build ahead of time, I think it's safer to set TkAgg as the default backend on macs.