### PR TITLE
Cleanup build matrix for matplotlib 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,17 @@ matrix:
   allow_failures:
     - os: linux
       env:
+        - MB_PYTHON_VERSION=3.8
+        - NP_BUILD_DEP=1.17.3
+        - NP_TEST_DEP=1.17.3
+        - PLAT=i686
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.7
+        - PLAT=i686
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.6
         - PLAT=i686
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ env:
         - TEST_DEPENDS=
         - PLAT=x86_64
         - UNICODE_WIDTH=32
-        - NP_BUILD_DEP=1.11.3
-        - NP_TEST_DEP=1.11.3
+        - NP_BUILD_DEP=1.14.5
+        - NP_TEST_DEP=1.14.5
         - MANYLINUX_URL=https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com
         - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
         # Following generated with
@@ -33,20 +33,22 @@ matrix:
   include:
     - os: linux
       env:
-        - MB_PYTHON_VERSION=3.7
-        - NP_BUILD_DEP=1.14.5
-        - NP_TEST_DEP=1.14.5
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.7
-        - NP_BUILD_DEP=1.14.5
-        - NP_TEST_DEP=1.14.5
-        - PLAT=i686
+        - MB_PYTHON_VERSION=3.8
+        - NP_BUILD_DEP=1.17.3
+        - NP_TEST_DEP=1.17.3
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.8
-        - NP_BUILD_DEP=1.14.5
-        - NP_TEST_DEP=1.14.5
+        - NP_BUILD_DEP=1.17.3
+        - NP_TEST_DEP=1.17.3
+        - PLAT=i686
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.7
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.7
+        - PLAT=i686
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
@@ -57,17 +59,15 @@ matrix:
     - os: osx
       language: generic
       env:
-        - MB_PYTHON_VERSION=3.7
+        - MB_PYTHON_VERSION=3.8
         - MB_PYTHON_OSX_VER=10.9
-        - NP_BUILD_DEP=1.14.5
-        - NP_TEST_DEP=1.14.5
+        - NP_BUILD_DEP=1.17.3
+        - NP_TEST_DEP=1.17.3
     - os: osx
       language: generic
       env:
-        - MB_PYTHON_VERSION=3.8
+        - MB_PYTHON_VERSION=3.7
         - MB_PYTHON_OSX_VER=10.9
-        - NP_BUILD_DEP=1.14.5
-        - NP_TEST_DEP=1.14.5
     - os: osx
       language: generic
       env:
@@ -76,17 +76,6 @@ matrix:
   allow_failures:
     - os: linux
       env:
-        - MB_PYTHON_VERSION=3.7
-        - NP_BUILD_DEP=1.14.5
-        - NP_TEST_DEP=1.14.5
-        - PLAT=i686
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.6
-        - PLAT=i686
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.5
         - PLAT=i686
 
 before_install:

--- a/config.sh
+++ b/config.sh
@@ -8,6 +8,10 @@ LOCAL_FT_COMMIT=5ad9b15
 NPROC=2
 PYTEST_ARGS="-ra --maxfail=1 --timeout=300 --durations=25 -n $NPROC"
 
+function pip_opts {
+    # Define extra pip arguments
+    echo "--prefer-binary"
+}
 
 function pre_build {
     # Any stuff that you need to do before you start building the wheels

--- a/config.sh
+++ b/config.sh
@@ -6,7 +6,7 @@ LOCAL_FT_COMMIT=5ad9b15
 
 # Test arguments
 NPROC=2
-PYTEST_ARGS="-ra --maxfail=1 --timeout=300 --durations=25 -n $NPROC"
+PYTEST_ARGS="-ra --maxfail=1000 --timeout=300 --durations=25 -n $NPROC"
 
 function pip_opts {
     # Define extra pip arguments


### PR DESCRIPTION
* Change the lower bound for numpy pinning
* Add a python 3.8 32 bit build.
* Remove repeated NP 1.14.5 pinning from most places
* Update numpy pinning for python 3.8